### PR TITLE
Removed unnecessary String clone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "wrut"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/backend/init.rs
+++ b/src/backend/init.rs
@@ -17,9 +17,9 @@ use walkdir::{DirEntry, WalkDir};
 ///     * This directory must already exist.
 /// * `name` - The name of the template to initialize
 ///     * If `name` is `None`, the name will be the name of the directory provided
-pub fn init_template(dir: PathBuf, name: &Option<String>) -> Result<()> {
+pub fn init_template(dir: PathBuf, name: Option<&str>) -> Result<()> {
     // register template
-    let template_name = get_name(name, &dir)?;
+    let template_name = get_name(&name, &dir)?;
     register(Type::Template, &dir, &template_name)?;
 
     // create template config
@@ -44,11 +44,11 @@ pub fn init_template(dir: PathBuf, name: &Option<String>) -> Result<()> {
 pub fn init_project(
     template: &String,
     project_dir: &PathBuf,
-    name: &Option<String>,
+    name: Option<&str>,
     config: PathBuf,
 ) -> Result<()> {
     // register project
-    let project_name = get_name(name, &project_dir)?;
+    let project_name = get_name(&name, &project_dir)?;
     register(Type::Project, &project_dir, &project_name)?;
 
     // get config
@@ -87,7 +87,6 @@ pub fn init_project(
 /// If the provided tag does not exist, this function will create a new tag directory under `~/.wrut/tags`.
 /// All entries in `templates` and `projects` will be added to their respective directories.
 pub fn init_tag(name: &String, templates: &Vec<String>, projects: &Vec<String>) -> Result<()> {
-    // TODO create new directory + subdirectories
     let tag_data_dir = setup::dir(setup::Dirs::Tags)?;
     let tag_dir = tag_data_dir.join(name);
     let tag_templates_dir = &tag_dir.join("templates");
@@ -101,7 +100,7 @@ pub fn init_tag(name: &String, templates: &Vec<String>, projects: &Vec<String>) 
     }
 
     // add templates/projects to appropriate dirs
-    // TODO check if already exists, don't try to create if it does
+    // check if already exists, don't try to create if it does
     let templates_dir = setup::dir(setup::Dirs::Templates)?;
     for template in templates {
         let template_path = &templates_dir.join(&template).canonicalize()?;
@@ -172,7 +171,7 @@ fn ignore(entry: &DirEntry, global_config: &Config, template_config: &Config) ->
 
 /// Acquire the name to use. If `name` is `None`, the name of the directory provided by `dir` will
 /// be used.
-fn get_name(name: &Option<String>, dir: &PathBuf) -> Result<String> {
+fn get_name(name: &Option<&str>, dir: &PathBuf) -> Result<String> {
     Ok(match name {
         Some(val) => val.to_string(),
         None => dir

--- a/src/cli/subcommands/project/parser.rs
+++ b/src/cli/subcommands/project/parser.rs
@@ -36,17 +36,15 @@ impl Command {
         Ok(match self {
             Command::List => println!("{}", list::list(Type::Project)?.join("\n")),
             Command::Init(args) => {
-                init::init_project(&args.template, &current_dir()?, &args.name, config)?
+                init::init_project(&args.template, &current_dir()?, args.name.as_deref(), config)?
             }
             Command::New(args) => {
                 let project_dir = current_dir()?.join(&args.name);
                 fs::create_dir(&project_dir)?;
-                // TODO remove this clone
-                // guess i should replace String with &str and some lifetimes?
                 init::init_project(
                     &args.template,
                     &project_dir,
-                    &Some(args.name.clone()),
+                    Some(&args.name),
                     config,
                 )?
             }

--- a/src/cli/subcommands/template/parser.rs
+++ b/src/cli/subcommands/template/parser.rs
@@ -29,7 +29,7 @@ impl Command {
     pub fn run(&self) -> Result<()> {
         Ok(match self {
             Command::List => println!("{}", list::list(Type::Template)?.join("\n")),
-            Command::Init(args) => init::init_template(current_dir()?, &args.name)?,
+            Command::Init(args) => init::init_template(current_dir()?, args.name.as_deref())?,
             Command::Remove(args) => remove::remove_template(&args.template)?,
         })
     }


### PR DESCRIPTION
An unnecessary `clone()` was called on a `String` in the `wrut project new` command. Removed by altering functions to take `Option<&str>` instead of `&Option<String>`.