### PR TITLE
Improved project/template storage + tag iteroperability

### DIFF
--- a/src/backend/project.rs
+++ b/src/backend/project.rs
@@ -1,11 +1,12 @@
 use crate::backend::utils::{get_name, ignore, register, unregister};
 use crate::list::list;
 use crate::setup::{dir, Dirs};
-use crate::{config::Config, Type, WrutError};
+use crate::{config::Config, Type, WrutError, Tag};
 use anyhow::Result;
 use std::env::current_dir;
 use std::path::PathBuf;
 use walkdir::WalkDir;
+use std::os::unix::fs::symlink;
 
 /// A struct representing a `wrut` project.
 pub struct Project {
@@ -60,9 +61,17 @@ impl Project {
     ///
     /// * `template` - The template to generate the project from
     /// * `config` - The path to the configuration file to use
-    pub fn init(&self, template: &String, config: PathBuf) -> Result<()> {
+    pub fn init(&self, template: &String, tags: &Vec<String>, config: PathBuf) -> Result<()> {
         // register project
         register(Type::Project, &self.path, &self.name)?;
+
+        // add tags to the project
+        let project_tags_dir = dir(Dirs::Projects)?.join(&self.name).join("tags");
+        for tag in tags {
+            let tag_dir = dir(Dirs::Tags)?.join(&tag);
+            symlink(&tag_dir, project_tags_dir.join(&tag))?;
+            Tag::from(&tag).init(&vec![], &vec![&self.name])?;
+        }
 
         // get full template directory, initialize directory walker
         let template_dir = dir(Dirs::Templates)?.join(template).join("path").canonicalize()?;
@@ -86,6 +95,7 @@ impl Project {
                 std::fs::copy(&source, &dest)?;
             }
         }
+
         Ok(())
     }
 
@@ -98,13 +108,13 @@ impl Project {
     ///
     /// * `template` - The template to generate the project from
     /// * `config` - The path to the configuration file to use
-    pub fn new_init(&self, template: &String, config: PathBuf) -> Result<()> {
+    pub fn new_init(&self, template: &String, tags: &Vec<String>, config: PathBuf) -> Result<()> {
         // Create new project directory
         let project_dir = current_dir()?.join(&self.name);
         std::fs::create_dir(&project_dir)?;
 
         // call normal init
-        self.init(template, config)
+        self.init(template, tags, config)
     }
 
     /// Remove the given project.

--- a/src/backend/project.rs
+++ b/src/backend/project.rs
@@ -32,14 +32,14 @@ impl Project {
     ///
     /// If no such project exists, it will return an error.
     pub fn get(name: &str) -> Result<Self> {
-        let projects_dir = dir(Dirs::Projects)?;
-        let project = projects_dir.join(name);
+        let project = dir(Dirs::Projects)?.join(name);
+        let project_link = project.join("path").canonicalize()?;
         let name = get_name(&None, &project)?;
 
-        if project.is_symlink() {
+        if project.is_dir() {
             Ok(Project {
                 name,
-                path: project,
+                path: project_link,
             })
         } else {
             Err(WrutError::NoSuchProject(project, name))?
@@ -65,7 +65,7 @@ impl Project {
         register(Type::Project, &self.path, &self.name)?;
 
         // get full template directory, initialize directory walker
-        let template_dir = dir(Dirs::Templates)?.join(template).canonicalize()?;
+        let template_dir = dir(Dirs::Templates)?.join(template).join("path").canonicalize()?;
         let walker = WalkDir::new(&template_dir)
             .min_depth(1)
             .follow_links(true)

--- a/src/backend/project.rs
+++ b/src/backend/project.rs
@@ -66,12 +66,7 @@ impl Project {
         register(Type::Project, &self.path, &self.name)?;
 
         // add tags to the project
-        let project_tags_dir = dir(Dirs::Projects)?.join(&self.name).join("tags");
-        for tag in tags {
-            let tag_dir = dir(Dirs::Tags)?.join(&tag);
-            symlink(&tag_dir, project_tags_dir.join(&tag))?;
-            Tag::from(&tag).init(&vec![], &vec![&self.name])?;
-        }
+        self.add_tags(tags)?;
 
         // get full template directory, initialize directory walker
         let template_dir = dir(Dirs::Templates)?.join(template).join("path").canonicalize()?;
@@ -115,6 +110,18 @@ impl Project {
 
         // call normal init
         self.init(template, tags, config)
+    }
+
+    /// Add tags to a project.
+    pub fn add_tags(&self, tags: &Vec<String>) -> Result<()> { 
+        let project_tags_dir = dir(Dirs::Projects)?.join(&self.name).join("tags");
+        for tag in tags {
+            let tag_dir = dir(Dirs::Tags)?.join(&tag);
+            symlink(&tag_dir, project_tags_dir.join(&tag))?;
+            Tag::from(&tag).init(&vec![], &vec![&self.name])?;
+        }
+
+        Ok(())
     }
 
     /// Remove the given project.

--- a/src/backend/project.rs
+++ b/src/backend/project.rs
@@ -135,6 +135,15 @@ impl Project {
             std::fs::remove_dir_all(&self.path)?;
         }
 
+        // delete projects in tags dir
+        let project_tags_dir = dir(Dirs::Projects)?.join(&self.name).join("tags");
+        for tag in project_tags_dir.read_dir()? {
+            let tag = tag?;
+            // TODO make safer
+            let tag = Tag::from(tag.file_name().to_str().unwrap());
+            tag.remove(&vec![], &vec![&self.name])?;
+        }
+
         unregister(Type::Project, &self.name)
     }
 }

--- a/src/backend/project.rs
+++ b/src/backend/project.rs
@@ -61,12 +61,9 @@ impl Project {
     ///
     /// * `template` - The template to generate the project from
     /// * `config` - The path to the configuration file to use
-    pub fn init(&self, template: &String, tags: &Vec<String>, config: PathBuf) -> Result<()> {
+    pub fn init(self, template: &String, config: PathBuf) -> Result<Self> {
         // register project
         register(Type::Project, &self.path, &self.name)?;
-
-        // add tags to the project
-        self.add_tags(tags)?;
 
         // get full template directory, initialize directory walker
         let template_dir = dir(Dirs::Templates)?.join(template).join("path").canonicalize()?;
@@ -91,7 +88,7 @@ impl Project {
             }
         }
 
-        Ok(())
+        Ok(self)
     }
 
     /// Create a new project directory and then initialize the project.
@@ -103,17 +100,17 @@ impl Project {
     ///
     /// * `template` - The template to generate the project from
     /// * `config` - The path to the configuration file to use
-    pub fn new_init(&self, template: &String, tags: &Vec<String>, config: PathBuf) -> Result<()> {
+    pub fn new_init(self, template: &String, config: PathBuf) -> Result<Self> {
         // Create new project directory
         let project_dir = current_dir()?.join(&self.name);
         std::fs::create_dir(&project_dir)?;
 
         // call normal init
-        self.init(template, tags, config)
+        self.init(template, config)
     }
 
     /// Add tags to a project.
-    pub fn add_tags(&self, tags: &Vec<String>) -> Result<()> { 
+    pub fn add_tags(self, tags: &Vec<String>) -> Result<Self> { 
         let project_tags_dir = dir(Dirs::Projects)?.join(&self.name).join("tags");
         for tag in tags {
             let tag_dir = dir(Dirs::Tags)?.join(&tag);
@@ -121,7 +118,7 @@ impl Project {
             Tag::from(&tag).init(&vec![], &vec![&self.name])?;
         }
 
-        Ok(())
+        Ok(self)
     }
 
     /// Remove the given project.

--- a/src/backend/project.rs
+++ b/src/backend/project.rs
@@ -1,12 +1,12 @@
 use crate::backend::utils::{get_name, ignore, register, unregister};
 use crate::list::list;
 use crate::setup::{dir, Dirs};
-use crate::{config::Config, Type, WrutError, Tag};
+use crate::{config::Config, Tag, Type, WrutError};
 use anyhow::Result;
 use std::env::current_dir;
+use std::os::unix::fs::symlink;
 use std::path::PathBuf;
 use walkdir::WalkDir;
-use std::os::unix::fs::symlink;
 
 /// A struct representing a `wrut` project.
 pub struct Project {
@@ -66,7 +66,10 @@ impl Project {
         register(Type::Project, &self.path, &self.name)?;
 
         // get full template directory, initialize directory walker
-        let template_dir = dir(Dirs::Templates)?.join(template).join("path").canonicalize()?;
+        let template_dir = dir(Dirs::Templates)?
+            .join(template)
+            .join("path")
+            .canonicalize()?;
         let walker = WalkDir::new(&template_dir)
             .min_depth(1)
             .follow_links(true)
@@ -110,7 +113,7 @@ impl Project {
     }
 
     /// Add tags to a project.
-    pub fn add_tags(self, tags: &Vec<String>) -> Result<Self> { 
+    pub fn add_tags(self, tags: &Vec<String>) -> Result<Self> {
         let project_tags_dir = dir(Dirs::Projects)?.join(&self.name).join("tags");
         for tag in tags {
             let tag_dir = dir(Dirs::Tags)?.join(&tag);

--- a/src/backend/tag.rs
+++ b/src/backend/tag.rs
@@ -73,7 +73,7 @@ impl Tag {
         Ok(std::str::from_utf8(&output.stdout)?.to_string())
     }
 
-    pub fn remove(&self, templates: &Vec<String>, projects: &Vec<String>) -> Result<()> {
+    pub fn remove(&self, templates: &Vec<&str>, projects: &Vec<&str>) -> Result<()> {
         if templates.len() == 0 && projects.len() == 0 {
             unregister(Type::Tag, &self.name)
         } else {

--- a/src/backend/tag.rs
+++ b/src/backend/tag.rs
@@ -40,14 +40,18 @@ impl Tag {
         for template in templates {
             let template_path = &templates_dir.join(&template).canonicalize()?;
             let tag_template_symlink = &tag_templates_dir.join(&template);
-            if !tag_template_symlink.is_symlink() { symlink(template_path, tag_template_symlink)?; }
+            if !tag_template_symlink.is_symlink() {
+                symlink(template_path, tag_template_symlink)?;
+            }
         }
 
         let projects_dir = dir(Dirs::Projects)?;
         for project in projects {
             let project_path = &projects_dir.join(&project).canonicalize()?;
             let tag_project_symlink = &tag_projects_dir.join(&project);
-            if !tag_project_symlink.is_symlink() { symlink(project_path, tag_project_symlink)?; }
+            if !tag_project_symlink.is_symlink() {
+                symlink(project_path, tag_project_symlink)?;
+            }
         }
 
         Ok(())
@@ -75,7 +79,7 @@ impl Tag {
         } else {
             let tag_templates_dir = dir(Dirs::Tags)?.join(&self.name).join("templates");
             let tag_projects_dir = dir(Dirs::Tags)?.join(&self.name).join("projects");
-            
+
             for template in templates {
                 let template_link = tag_templates_dir.join(template);
                 if template_link.is_symlink() {

--- a/src/backend/tag.rs
+++ b/src/backend/tag.rs
@@ -21,7 +21,7 @@ impl Tag {
     /// If the provided tag does not exist, this function will create a new tag directory under
     /// `~/.wrut/tags`. All entries in `templates` and `projects` will be added to their respective
     /// directories.
-    pub fn init(&self, templates: &Vec<String>, projects: &Vec<String>) -> Result<()> {
+    pub fn init(&self, templates: &Vec<&str>, projects: &Vec<&str>) -> Result<()> {
         let tag_data_dir = dir(Dirs::Tags)?;
         let tag_dir = tag_data_dir.join(&self.name);
         let tag_templates_dir = &tag_dir.join("templates");
@@ -40,14 +40,14 @@ impl Tag {
         for template in templates {
             let template_path = &templates_dir.join(&template).canonicalize()?;
             let tag_template_symlink = &tag_templates_dir.join(&template);
-            symlink(template_path, tag_template_symlink)?;
+            if !tag_template_symlink.is_symlink() { symlink(template_path, tag_template_symlink)?; }
         }
 
         let projects_dir = dir(Dirs::Projects)?;
         for project in projects {
             let project_path = &projects_dir.join(&project).canonicalize()?;
             let tag_project_symlink = &tag_projects_dir.join(&project);
-            symlink(project_path, tag_project_symlink)?;
+            if !tag_project_symlink.is_symlink() { symlink(project_path, tag_project_symlink)?; }
         }
 
         Ok(())

--- a/src/backend/template.rs
+++ b/src/backend/template.rs
@@ -89,6 +89,15 @@ impl Template {
             std::fs::remove_dir_all(&self.path)?;
         }
 
+        // delete templates in tags dir
+        let template_tags_dir = dir(Dirs::Templates)?.join(&self.name).join("tags");
+        for tag in template_tags_dir.read_dir()? {
+            let tag = tag?;
+            // TODO make safer
+            let tag = Tag::from(tag.file_name().to_str().unwrap());
+            tag.remove(&vec![], &vec![&self.name])?;
+        }
+
         unregister(Type::Template, &self.name)
     }
 }

--- a/src/backend/template.rs
+++ b/src/backend/template.rs
@@ -55,21 +55,19 @@ impl Template {
     ///
     /// This function will create a `.wrut.toml` file in the provided directory and register a symlink
     /// to `dir` in `~/.wrut/templates`.
-    pub fn init(&self, tags: &Vec<String>) -> Result<()> {
+    pub fn init(self) -> Result<Self> {
         // register template
         register(Type::Template, &self.path, &self.name)?;
-
-        // add tags to the template
-        self.add_tags(tags)?;
 
         // create template config
         let mut template_config = std::fs::File::create(&self.path.join(".wrut.toml"))?;
         write!(template_config, "{}", Config::default().to_string())?;
 
-        Ok(())
+        Ok(self)
     }
 
-    pub fn add_tags(&self, tags: &Vec<String>) -> Result<()> {
+    /// Add tags to a template.
+    pub fn add_tags(self, tags: &Vec<String>) -> Result<Self> {
         let template_tags_dir = dir(Dirs::Templates)?.join(&self.name).join("tags");
         for tag in tags {
             let tag_dir = dir(Dirs::Tags)?.join(&tag);
@@ -77,7 +75,7 @@ impl Template {
             Tag::from(&tag).init(&vec![], &vec![&self.name])?;
         }
 
-        Ok(())
+        Ok(self)
     }
 
     /// Remove the given project.

--- a/src/backend/template.rs
+++ b/src/backend/template.rs
@@ -60,16 +60,22 @@ impl Template {
         register(Type::Template, &self.path, &self.name)?;
 
         // add tags to the template
+        self.add_tags(tags)?;
+
+        // create template config
+        let mut template_config = std::fs::File::create(&self.path.join(".wrut.toml"))?;
+        write!(template_config, "{}", Config::default().to_string())?;
+
+        Ok(())
+    }
+
+    pub fn add_tags(&self, tags: &Vec<String>) -> Result<()> {
         let template_tags_dir = dir(Dirs::Templates)?.join(&self.name).join("tags");
         for tag in tags {
             let tag_dir = dir(Dirs::Tags)?.join(&tag);
             symlink(&tag_dir, template_tags_dir.join(&tag))?;
             Tag::from(&tag).init(&vec![], &vec![&self.name])?;
         }
-
-        // create template config
-        let mut template_config = std::fs::File::create(&self.path.join(".wrut.toml"))?;
-        write!(template_config, "{}", Config::default().to_string())?;
 
         Ok(())
     }

--- a/src/backend/template.rs
+++ b/src/backend/template.rs
@@ -31,14 +31,14 @@ impl Template {
     ///
     /// If no such project exists, it will return an error.
     pub fn get(name: &str) -> Result<Self> {
-        let templates_dir = dir(Dirs::Templates)?;
-        let template = templates_dir.join(name);
+        let template = dir(Dirs::Templates)?.join(name);
+        let template_link = template.join("path").canonicalize()?;
         let name = get_name(&None, &template)?;
 
         if template.is_symlink() {
             Ok(Self {
                 name,
-                path: template,
+                path: template_link,
             })
         } else {
             Err(WrutError::NoSuchProject(template, name))?

--- a/src/backend/template.rs
+++ b/src/backend/template.rs
@@ -1,11 +1,11 @@
 use crate::backend::utils::{get_name, register, unregister};
 use crate::list::list;
 use crate::setup::{dir, Dirs};
-use crate::{config::Config, Type, WrutError, Tag};
+use crate::{config::Config, Tag, Type, WrutError};
 use anyhow::Result;
 use std::io::Write;
-use std::path::PathBuf;
 use std::os::unix::fs::symlink;
+use std::path::PathBuf;
 
 /// A struct representing a `wrut` template.
 pub struct Template {

--- a/src/backend/template.rs
+++ b/src/backend/template.rs
@@ -1,10 +1,11 @@
 use crate::backend::utils::{get_name, register, unregister};
 use crate::list::list;
 use crate::setup::{dir, Dirs};
-use crate::{config::Config, Type, WrutError};
+use crate::{config::Config, Type, WrutError, Tag};
 use anyhow::Result;
 use std::io::Write;
 use std::path::PathBuf;
+use std::os::unix::fs::symlink;
 
 /// A struct representing a `wrut` template.
 pub struct Template {
@@ -54,9 +55,17 @@ impl Template {
     ///
     /// This function will create a `.wrut.toml` file in the provided directory and register a symlink
     /// to `dir` in `~/.wrut/templates`.
-    pub fn init(&self) -> Result<()> {
+    pub fn init(&self, tags: &Vec<String>) -> Result<()> {
         // register template
         register(Type::Template, &self.path, &self.name)?;
+
+        // add tags to the template
+        let template_tags_dir = dir(Dirs::Templates)?.join(&self.name).join("tags");
+        for tag in tags {
+            let tag_dir = dir(Dirs::Tags)?.join(&tag);
+            symlink(&tag_dir, template_tags_dir.join(&tag))?;
+            Tag::from(&tag).init(&vec![], &vec![&self.name])?;
+        }
 
         // create template config
         let mut template_config = std::fs::File::create(&self.path.join(".wrut.toml"))?;

--- a/src/cli/subcommands/project/init.rs
+++ b/src/cli/subcommands/project/init.rs
@@ -12,4 +12,9 @@ pub struct InitArgs {
     ///
     /// By default, the name of the current directory will be used.
     pub name: Option<String>,
+
+    /// Tags to add to the project
+    #[clap(long, short, value_delimiter = ',')]
+    #[clap(hide_possible_values = true, value_parser = PossibleValuesParser::new(get_values(Type::Tag)))]
+    pub tags: Vec<String>,
 }

--- a/src/cli/subcommands/project/new.rs
+++ b/src/cli/subcommands/project/new.rs
@@ -9,4 +9,9 @@ pub struct NewArgs {
     pub template: String,
     /// The name of the project to initialize.
     pub name: String,
+
+    /// Tags to add to the project
+    #[clap(long, short, value_delimiter = ',')]
+    #[clap(hide_possible_values = true, value_parser = PossibleValuesParser::new(get_values(Type::Tag)))]
+    pub tags: Vec<String>,
 }

--- a/src/cli/subcommands/project/parser.rs
+++ b/src/cli/subcommands/project/parser.rs
@@ -35,11 +35,11 @@ impl Command {
         Ok(match self {
             Command::List => println!("{}", Project::list()?.join("\n")),
             Command::Init(args) => {
-                Project::from(current_dir()?, args.name.as_deref())?.init(&args.template, config)?
+                Project::from(current_dir()?, args.name.as_deref())?.init(&args.template, &args.tags, config)?
             }
             Command::New(args) => {
                 Project::from(current_dir()?.join(&args.name), Some(&args.name))?
-                    .new_init(&args.template, config)?;
+                    .new_init(&args.template, &args.tags, config)?;
             }
             Command::Remove(args) => Project::get(&args.project)?.remove(args.delete)?,
         })

--- a/src/cli/subcommands/project/parser.rs
+++ b/src/cli/subcommands/project/parser.rs
@@ -35,11 +35,11 @@ impl Command {
         Ok(match self {
             Command::List => println!("{}", Project::list()?.join("\n")),
             Command::Init(args) => {
-                Project::from(current_dir()?, args.name.as_deref())?.init(&args.template, &args.tags, config)?
+                Project::from(current_dir()?, args.name.as_deref())?.init(&args.template, config)?.add_tags(&args.tags)?;
             }
             Command::New(args) => {
                 Project::from(current_dir()?.join(&args.name), Some(&args.name))?
-                    .new_init(&args.template, &args.tags, config)?;
+                    .new_init(&args.template, config)?.add_tags(&args.tags)?;
             }
             Command::Remove(args) => Project::get(&args.project)?.remove(args.delete)?,
         })

--- a/src/cli/subcommands/project/parser.rs
+++ b/src/cli/subcommands/project/parser.rs
@@ -35,11 +35,14 @@ impl Command {
         Ok(match self {
             Command::List => println!("{}", Project::list()?.join("\n")),
             Command::Init(args) => {
-                Project::from(current_dir()?, args.name.as_deref())?.init(&args.template, config)?.add_tags(&args.tags)?;
+                Project::from(current_dir()?, args.name.as_deref())?
+                    .init(&args.template, config)?
+                    .add_tags(&args.tags)?;
             }
             Command::New(args) => {
                 Project::from(current_dir()?.join(&args.name), Some(&args.name))?
-                    .new_init(&args.template, config)?.add_tags(&args.tags)?;
+                    .new_init(&args.template, config)?
+                    .add_tags(&args.tags)?;
             }
             Command::Remove(args) => Project::get(&args.project)?.remove(args.delete)?,
         })

--- a/src/cli/subcommands/tag/parser.rs
+++ b/src/cli/subcommands/tag/parser.rs
@@ -35,12 +35,10 @@ impl Command {
                 &args.templates.iter().map(|t| t.as_ref()).collect(),
                 &args.projects.iter().map(|p| p.as_ref()).collect(),
             )?,
-            Command::Remove(args) => {
-                Tag::from(&args.name).remove(
-                    &args.templates.iter().map(|t| t.as_ref()).collect(), 
-                    &args.projects.iter().map(|p| p.as_ref()).collect(),
-                )?
-            }
+            Command::Remove(args) => Tag::from(&args.name).remove(
+                &args.templates.iter().map(|t| t.as_ref()).collect(),
+                &args.projects.iter().map(|p| p.as_ref()).collect(),
+            )?,
         })
     }
 }

--- a/src/cli/subcommands/tag/parser.rs
+++ b/src/cli/subcommands/tag/parser.rs
@@ -31,7 +31,7 @@ impl Command {
     pub fn run(&self) -> Result<()> {
         Ok(match self {
             Command::List(args) => println!("{}", Tag::list(&args.name)?),
-            Command::New(args) => Tag::from(&args.name).init(&args.templates, &args.projects)?,
+            Command::New(args) => Tag::from(&args.name).init(&args.templates.iter().map(|t| t.as_ref()).collect(), &args.projects.iter().map(|p| p.as_ref()).collect())?,
             Command::Remove(args) => Tag::from(&args.name).remove(&args.templates, &args.projects)?,
         })
     }

--- a/src/cli/subcommands/tag/parser.rs
+++ b/src/cli/subcommands/tag/parser.rs
@@ -31,8 +31,13 @@ impl Command {
     pub fn run(&self) -> Result<()> {
         Ok(match self {
             Command::List(args) => println!("{}", Tag::list(&args.name)?),
-            Command::New(args) => Tag::from(&args.name).init(&args.templates.iter().map(|t| t.as_ref()).collect(), &args.projects.iter().map(|p| p.as_ref()).collect())?,
-            Command::Remove(args) => Tag::from(&args.name).remove(&args.templates, &args.projects)?,
+            Command::New(args) => Tag::from(&args.name).init(
+                &args.templates.iter().map(|t| t.as_ref()).collect(),
+                &args.projects.iter().map(|p| p.as_ref()).collect(),
+            )?,
+            Command::Remove(args) => {
+                Tag::from(&args.name).remove(&args.templates, &args.projects)?
+            }
         })
     }
 }

--- a/src/cli/subcommands/tag/parser.rs
+++ b/src/cli/subcommands/tag/parser.rs
@@ -36,7 +36,10 @@ impl Command {
                 &args.projects.iter().map(|p| p.as_ref()).collect(),
             )?,
             Command::Remove(args) => {
-                Tag::from(&args.name).remove(&args.templates, &args.projects)?
+                Tag::from(&args.name).remove(
+                    &args.templates.iter().map(|t| t.as_ref()).collect(), 
+                    &args.projects.iter().map(|p| p.as_ref()).collect(),
+                )?
             }
         })
     }

--- a/src/cli/subcommands/template/init.rs
+++ b/src/cli/subcommands/template/init.rs
@@ -6,4 +6,9 @@ pub struct InitArgs {
     ///
     /// By default, the name of the current directory will be used.
     pub name: Option<String>,
+
+    /// Tags to add to the template
+    #[clap(long, short, value_delimiter = ',')]
+    #[clap(hide_possible_values = true, value_parser = PossibleValuesParser::new(get_values(Type::Tag)))]
+    pub tags: Vec<String>,
 }

--- a/src/cli/subcommands/template/init.rs
+++ b/src/cli/subcommands/template/init.rs
@@ -1,4 +1,6 @@
-use clap::Args;
+use clap::{builder::PossibleValuesParser, Args};
+use crate::cli::util::get_values;
+use wrut::Type;
 
 #[derive(Args, Debug)]
 pub struct InitArgs {

--- a/src/cli/subcommands/template/init.rs
+++ b/src/cli/subcommands/template/init.rs
@@ -1,5 +1,5 @@
-use clap::{builder::PossibleValuesParser, Args};
 use crate::cli::util::get_values;
+use clap::{builder::PossibleValuesParser, Args};
 use wrut::Type;
 
 #[derive(Args, Debug)]

--- a/src/cli/subcommands/template/parser.rs
+++ b/src/cli/subcommands/template/parser.rs
@@ -29,7 +29,11 @@ impl Command {
     pub fn run(&self) -> Result<()> {
         Ok(match self {
             Command::List => println!("{}", Template::list()?.join("\n")),
-            Command::Init(args) => { let _ = Template::from(current_dir()?, args.name.as_deref())?.init()?.add_tags(&args.tags); },
+            Command::Init(args) => {
+                let _ = Template::from(current_dir()?, args.name.as_deref())?
+                    .init()?
+                    .add_tags(&args.tags);
+            }
             Command::Remove(args) => Template::get(&args.template)?.remove(args.delete)?,
         })
     }

--- a/src/cli/subcommands/template/parser.rs
+++ b/src/cli/subcommands/template/parser.rs
@@ -29,7 +29,7 @@ impl Command {
     pub fn run(&self) -> Result<()> {
         Ok(match self {
             Command::List => println!("{}", Template::list()?.join("\n")),
-            Command::Init(args) => Template::from(current_dir()?, args.name.as_deref())?.init()?,
+            Command::Init(args) => Template::from(current_dir()?, args.name.as_deref())?.init(&args.tags)?,
             Command::Remove(args) => Template::get(&args.template)?.remove(args.delete)?,
         })
     }

--- a/src/cli/subcommands/template/parser.rs
+++ b/src/cli/subcommands/template/parser.rs
@@ -29,7 +29,7 @@ impl Command {
     pub fn run(&self) -> Result<()> {
         Ok(match self {
             Command::List => println!("{}", Template::list()?.join("\n")),
-            Command::Init(args) => Template::from(current_dir()?, args.name.as_deref())?.init(&args.tags)?,
+            Command::Init(args) => { let _ = Template::from(current_dir()?, args.name.as_deref())?.init()?.add_tags(&args.tags); },
             Command::Remove(args) => Template::get(&args.template)?.remove(args.delete)?,
         })
     }


### PR DESCRIPTION
Changed project/template storage format from just a symlink to a directory containing a `tags` directory and a `path` symlink to the project/template source directory. Improved tag interoperability by allowing tag management from project/template commands.